### PR TITLE
Fix missing imports for audio and haptics

### DIFF
--- a/LanePace/AdvancedTimerViewModel.swift
+++ b/LanePace/AdvancedTimerViewModel.swift
@@ -9,6 +9,8 @@ import Foundation
 import Combine
 import SwiftUI
 import AVFoundation
+import AudioToolbox
+import UIKit
 
 final class AdvancedTimerViewModel: ObservableObject {
     


### PR DESCRIPTION
## Summary
- add required UIKit and AudioToolbox imports to AdvancedTimerViewModel

## Testing
- `xcodebuild -project LanePace.xcodeproj -scheme LanePace -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ad56e32fe88333b0964c850b717c01